### PR TITLE
fix: normalize CNAME record target by removing trailing dot to avoid …

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -46,10 +46,14 @@ func (c *Client) ListRecords(ctx context.Context) ([]Record, error) {
 
 	var records []Record
 	for _, rs := range dnsZone.Records {
+		rdata := rs.RData
+		if len(rdata) > 0 && rdata[len(rdata)-1] == '.' {
+			rdata = rdata[:len(rdata)-1]
+		}
 		rec := Record{
 			Type:    string(rs.Type),
 			Name:    rs.Name,
-			Targets: []string{rs.RData},
+			Targets: []string{rdata},
 			TTL:     rs.TTL,
 		}
 		log.Printf("Found record: %s %s -> %v (TTL=%d)", rec.Type, rec.Name, rec.Targets, rec.TTL)


### PR DESCRIPTION
# 目的

- CNAMEレコードのtarget値の末尾にドットが付いている場合と付いていない場合で比較が一致しない問題を解消するため。
- DNSレコードの更新や比較処理で、target値の表記揺れによる不具合を防止する。

# 変更の要点

- ListRecordsで取得したCNAMEレコードのtarget値の末尾にドットがあれば自動で除去するように修正。
- これにより、target値の比較時に末尾のドット有無による差異が発生しなくなる。